### PR TITLE
Add deployment config: Render API + GitHub Pages frontend

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,58 @@
+name: Deploy web to GitHub Pages
+
+# Builds web/ (Vite) and publishes the static site to GitHub Pages.
+# Repo Settings → Pages → Source must be set to "GitHub Actions".
+# The VITE_* values are build-time, injected from repo Variables
+# (Settings → Secrets and variables → Actions → Variables). The Supabase
+# publishable key is safe to expose publicly — RLS protects the data.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "web/**"
+      - ".github/workflows/deploy-web.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - name: Install deps
+        working-directory: web
+        run: npm ci
+      - name: Build
+        working-directory: web
+        env:
+          VITE_SUPABASE_URL: ${{ vars.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_PUBLISHABLE_KEY: ${{ vars.VITE_SUPABASE_PUBLISHABLE_KEY }}
+          VITE_API_URL: ${{ vars.VITE_API_URL }}
+        run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: web/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,64 @@
+# Deploying NHA
+
+Three pieces: **Supabase** (DB + Auth, already live), the **API** on Render, and
+the **frontend** on GitHub Pages. Do them in this order — the frontend build needs
+the API's URL.
+
+```
+Browser ──reads──▶ Supabase (RLS)
+   │   ──writes──▶ Render API ──▶ Supabase
+   ▼
+GitHub Pages (static React)
+```
+
+Reads (standings, rosters, leaders, login) go straight to Supabase and are always
+fast. Only writes (lineup save, trades) hit the API.
+
+## 1. API → Render
+
+1. Push this branch to GitHub (`render.yaml` is at the repo root).
+2. Render dashboard → **New → Blueprint** → connect this repo → it reads
+   `render.yaml` and creates the `nha-api` service.
+3. Set the one secret it asks for: **`HANDBALL_DB_URL`** = your Supabase
+   **Session pooler** string, rewritten to `postgresql+psycopg://…`
+   (Supabase → Connect → Session pooler; swap the `postgresql://` prefix).
+4. Deploy. Note the URL, e.g. `https://nha-api.onrender.com`. Check
+   `https://nha-api.onrender.com/health` returns `{"ok":true}`.
+
+> Free tier sleeps after ~15 min idle; the first write after that waits ~30s
+> (the Save button shows "Saving…"). Reads/login are unaffected.
+
+## 2. Frontend → GitHub Pages
+
+1. Repo **Settings → Pages → Source → GitHub Actions**.
+2. Repo **Settings → Secrets and variables → Actions → Variables** → add three
+   **repository variables** (all public-safe):
+   - `VITE_SUPABASE_URL` = `https://dabgpgjwvarojclnpptf.supabase.co`
+   - `VITE_SUPABASE_PUBLISHABLE_KEY` = your `sb_publishable_…` key
+   - `VITE_API_URL` = the Render URL from step 1
+3. Merge to `main` (or run the **Deploy web to GitHub Pages** workflow manually).
+   It builds `web/` and publishes to **`https://oliverhvidsten.github.io/handball/`**.
+
+## 3. Supabase wiring
+
+- **Authentication → URL Configuration** → add
+  `https://oliverhvidsten.github.io/handball` as a Site URL / redirect URL.
+- The API already allows the Pages origin via `NHA_CORS_ORIGINS` in `render.yaml`.
+  (If you later use a custom domain, add it there and redeploy the API.)
+
+## 4. Add managers
+
+Each manager needs a Supabase **auth user** + a `managers` row + `owner_id` on
+their team(s). Use `scripts/seed_owner.py` as the pattern (it sets ownership for a
+given auth email). New managers self-serve once you create their auth user and
+assign their teams.
+
+## Notes
+
+- **Custom domain:** set it in Pages settings, add it to `NHA_CORS_ORIGINS`
+  (render.yaml) and the Supabase redirect URLs.
+- **Private league:** Pages sites are public on the free plan. The *data* is still
+  protected by Supabase Auth + RLS (you can't read anything without logging in),
+  but the app shell/login page is publicly reachable.
+- **Keep-warm (optional later):** if the ~30s cold start becomes annoying, add a
+  scheduled workflow that pings `/health` every ~10 min.

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,26 @@
+# Render blueprint for the NHA write API (FastAPI).
+# Render free web services sleep after ~15 min idle (first request then waits
+# ~30s); only WRITE actions (lineup save, trades) hit this API — all reads go
+# straight to Supabase, so browsing/login are never affected.
+#
+# Deploy: push this file, then in the Render dashboard create a "Blueprint"
+# from the repo. Set HANDBALL_DB_URL as a secret (it's marked sync:false).
+services:
+  - type: web
+    name: nha-api
+    runtime: python
+    region: oregon          # same region as the Supabase project (low latency)
+    plan: free
+    rootDir: .
+    buildCommand: "pip install -e '.[api]'"
+    startCommand: "uvicorn api.main:app --host 0.0.0.0 --port $PORT"
+    healthCheckPath: /health
+    envVars:
+      - key: PYTHON_VERSION
+        value: "3.12"
+      - key: HANDBALL_DB_URL          # Supabase SESSION POOLER, postgresql+psycopg://...
+        sync: false                   # secret — set in the Render dashboard
+      - key: SUPABASE_URL             # for JWKS token verification
+        value: https://dabgpgjwvarojclnpptf.supabase.co
+      - key: NHA_CORS_ORIGINS         # the GitHub Pages origin (allow the browser app)
+        value: https://oliverhvidsten.github.io

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,16 +1,19 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
+// HashRouter (not BrowserRouter): GitHub Pages has no server to rewrite deep
+// links, so path routing would 404 on refresh. Hash routing (/#/dashboard) is
+// served entirely client-side and needs no Pages config.
+import { HashRouter } from "react-router-dom";
 import { AuthProvider } from "./auth";
 import App from "./App";
 import "./ds/styles.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <HashRouter>
       <AuthProvider>
         <App />
       </AuthProvider>
-    </BrowserRouter>
+    </HashRouter>
   </React.StrictMode>
 );

--- a/web/src/pages/Roster.tsx
+++ b/web/src/pages/Roster.tsx
@@ -55,6 +55,7 @@ export default function Roster() {
   const [problems, setProblems] = useState<string[]>([]);
   const [toast, setToast] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
 
   const load = useCallback(async () => {
     setProblems([]);
@@ -127,6 +128,7 @@ export default function Roster() {
   async function save() {
     setProblems([]);
     setErr(null);
+    setSaving(true); // shows feedback through a slow first request (cold-start host)
     try {
       await apiFetch(`/teams/${slug}/arrangement`, { method: "PUT", body: JSON.stringify(arr) });
       setToast("Lineup saved.");
@@ -134,6 +136,8 @@ export default function Roster() {
     } catch (e) {
       if (e instanceof ApiError && e.problems) setProblems(e.problems);
       else setErr(e instanceof Error ? e.message : "save failed");
+    } finally {
+      setSaving(false);
     }
   }
 
@@ -166,8 +170,10 @@ export default function Roster() {
 
       {editable && (
         <div style={{ display: "flex", gap: 8, marginTop: 20 }}>
-          <Button variant="primary" onClick={save}>Save lineup</Button>
-          <Button onClick={() => setArr(buildArr(players))}>Reset</Button>
+          <Button variant="primary" onClick={save} disabled={saving}>
+            {saving ? "Saving…" : "Save lineup"}
+          </Button>
+          <Button onClick={() => setArr(buildArr(players))} disabled={saving}>Reset</Button>
         </div>
       )}
 


### PR DESCRIPTION
- main.tsx: BrowserRouter -> HashRouter so deep links/refresh work on Pages (no server to rewrite routes).
- render.yaml: Render blueprint for the FastAPI write API (free plan; pip install -e '.[api]', uvicorn; HANDBALL_DB_URL secret, SUPABASE_URL + NHA_CORS_ORIGINS set; /health check).
- .github/workflows/deploy-web.yml: build web/ and publish to GitHub Pages (VITE_* injected from repo Variables; publishable key is public-safe).
- Roster: "Saving…" busy state on the lineup-save button so the first write after a Render cold start shows feedback instead of looking frozen.
- DEPLOY.md: ordered account-side steps (API -> Pages -> Supabase wiring).