### PR TITLE
Declare numpy dependency (fixes Render deploy)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(
     version="0.1",
     packages=find_packages(),
     install_requires=[
+        "numpy>=1.26",          # used by handball.players / domain (core import path)
         "sqlalchemy>=2",
         "psycopg[binary]>=3",
         "alembic>=1.13",


### PR DESCRIPTION
handball.players imports numpy, so the API import chain (api.main → trade_service → domain → players) needs it at startup. It was missing from install_requires and only worked locally because numpy was already present globally; in a clean environment (Render) the service crashed on boot → health check failed → deploy failed.

Verified in a fresh venv: `pip install -e '.[api]'` then `import api.main` succeeds and uvicorn serves /health with no DB reachable.